### PR TITLE
Upgrade to Vaadin 25.1.1 and Spring Boot 4.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Vaadin Observability Kit Demo — a Vaadin 24.9.5 + Spring Boot 3.5.7 + Java 21 application demonstrating observability/tracing with OpenTelemetry. Uses H2 in-memory database, Spring Data JPA, and the Vaadin Observability Kit Agent (3.1.0).
+
+## Build & Run Commands
+
+```bash
+# Development mode (hot reload)
+./mvnw spring-boot:run
+
+# Production build
+./mvnw clean package -Pproduction
+
+# Run integration tests (requires Docker for Playwright + Grafana containers)
+./mvnw clean package -Pproduction && ./mvnw verify -Pproduction,it
+
+# Start observability backends (from project root)
+cd observability-kit && ./startObservabilityGrafana.sh      # Grafana stack
+cd observability-kit && ./startObservabilityNewRelic.sh      # New Relic
+cd observability-kit && ./startObservabilityJaegerPrometheusDocker.sh  # Jaeger + Prometheus
+```
+
+## Architecture
+
+**Layered Spring Boot + Vaadin Flow (server-driven UI):**
+
+- **Views** (`src/main/java/.../views/`): Vaadin Flow `@Route` components. `MainLayout` provides the app shell with navigation drawer. Each view is a self-contained UI with its own route.
+- **Data layer** (`src/main/java/.../data/`): JPA entities extending `AbstractEntity` (UUID-based), Spring Data repositories, and `@Service` classes.
+- **Frontend** (`frontend/`): Vaadin theme "kitstest" and auto-generated TypeScript. No separate SPA framework — UI is server-driven.
+- **Observability config** (`observability-kit/`): Agent config files for different backends (Grafana OTLP, Jaeger, Prometheus, New Relic), shell scripts to start each stack, and Docker compose for Grafana.
+
+## Testing
+
+Integration tests use **Playwright** running in a Docker container (port 3001 via CDP) against the Spring Boot app (random port). Test class: `PlaywrightIT.java`. Tests navigate views, verify Grafana dashboards, and check Prometheus metrics. Screenshots are saved to `target/`.
+
+The `it` Maven profile starts the app with the observability agent via `spring-boot-maven-plugin` and configures Failsafe for integration tests.
+
+## Key Ports
+
+| Service     | Port |
+|-------------|------|
+| Demo App    | 8080 |
+| Grafana     | 3000 |
+| Playwright  | 3001 |
+| Prometheus  | 9090 |
+| Jaeger UI   | 16686 |
+
+## Demo Views Purpose
+
+The views are intentionally designed to demonstrate observability scenarios:
+- **AboutView**: CPU cooker (stress test), bulk user generator, "Blow up" button for exception tracing
+- **ImageListView**: Intentional memory leak demo (~1GB per click)
+- **MasterDetailView**: Intentionally slow/unoptimized (cascading DB queries visible in traces)
+- **OptMasterDetailView**: Optimized version of the same functionality
+- **HelloWorldView**: Custom OpenTelemetry span example
+- **DashboardView**: System metrics display
+
+## Notes
+
+- Requires a Vaadin license for production builds
+- The `observability-grafana-setup` directory is a git submodule
+- Docker should run as non-root user (no sudo)
+- The observability agent JAR is downloaded at runtime by shell scripts from Maven Central

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Vaadin Observability Kit Demo — a Vaadin 24.9.5 + Spring Boot 3.5.7 + Java 21 application demonstrating observability/tracing with OpenTelemetry. Uses H2 in-memory database, Spring Data JPA, and the Vaadin Observability Kit Agent (3.1.0).
+Vaadin Observability Kit Demo — a Vaadin 25.0.2 + Spring Boot 4.0.2 + Java 21 application demonstrating observability/tracing with OpenTelemetry. Uses H2 in-memory database, Spring Data JPA, and the Vaadin Observability Kit Agent (3.1.0).
 
 ## Build & Run Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Vaadin Observability Kit Demo — a Vaadin 25.0.2 + Spring Boot 4.0.2 + Java 21 application demonstrating observability/tracing with OpenTelemetry. Uses H2 in-memory database, Spring Data JPA, and the Vaadin Observability Kit Agent (3.1.0).
+Vaadin Observability Kit Demo — a Vaadin 25.1.1 + Spring Boot 4.0.5 + Java 21 application demonstrating observability/tracing with OpenTelemetry. Uses H2 in-memory database, Spring Data JPA, and the Vaadin Observability Kit Agent (3.1.0).
 
 ## Build & Run Commands
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observability Kit Demo
 
-A test/demo setup for Observability Kit. For the Grafana part, this project references (as a submodule) the project: https://github.com/petrixh/observability-grafana-setup
+A test/demo setup for Observability Kit using **Vaadin 25.0.2** and **Spring Boot 4.0.2** (Java 21). For the Grafana part, this project references (as a submodule) the project: https://github.com/petrixh/observability-grafana-setup
 
 It is recommended that you run this on a system with: 
 - 4 or "multiple" cores/threads (some leaky ops are heavy, but it will always use one less than available unless only one is available)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observability Kit Demo
 
-A test/demo setup for Observability Kit using **Vaadin 25.0.2** and **Spring Boot 4.0.2** (Java 21). For the Grafana part, this project references (as a submodule) the project: https://github.com/petrixh/observability-grafana-setup
+A test/demo setup for Observability Kit using **Vaadin 25.1.1** and **Spring Boot 4.0.5** (Java 21). For the Grafana part, this project references (as a submodule) the project: https://github.com/petrixh/observability-grafana-setup
 
 It is recommended that you run this on a system with: 
 - 4 or "multiple" cores/threads (some leaky ops are heavy, but it will always use one less than available unless only one is available)

--- a/frontend/themes/kitstest/theme.json
+++ b/frontend/themes/kitstest/theme.json
@@ -1,3 +1,2 @@
 {
-  "lumoImports" : [ "typography", "color", "spacing", "badge", "utility" ]
 }

--- a/frontend/themes/kitstest/views/dashboard-view.css
+++ b/frontend/themes/kitstest/views/dashboard-view.css
@@ -1,19 +1,18 @@
-/* Borders */
+/* Dashboard rows - replaces vaadin-board-row from removed Board component */
 
-.dashboard-view vaadin-board-row > * {
+.dashboard-view .dashboard-row {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.dashboard-view .dashboard-row > * {
+  flex: 1 1 0;
+  min-width: 200px;
   border-bottom: 1px solid var(--lumo-contrast-10pct);
   border-right: 1px solid var(--lumo-contrast-10pct);
 }
 
-.dashboard-view vaadin-board-row.small > * {
-  border-right: none;
-}
-
-.dashboard-view vaadin-board-row.medium > *:nth-child(even),
-.dashboard-view vaadin-board-row.medium > *:only-child {
-  border-right: none;
-}
-
-.dashboard-view vaadin-board-row.large > *:last-child {
+.dashboard-view .dashboard-row > *:last-child {
   border-right: none;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <java.version>21</java.version>
         <!-- <vaadin.version>24.5.0.beta2</vaadin.version> -->
-        <vaadin.version>25.0.2</vaadin.version>
+        <vaadin.version>25.1.1</vaadin.version>
         <!-- How to figure this out? Go to https://github.com/vaadin/observability-kit -> Tag -> find the version that matches the vaadin-obskit jar you downloaded -> check the pom.xml property for "opentelemetry.javaagent.version" -->
         <!--<open.telemetry.annotation.version>1.23.0</open.telemetry.annotation.version>
         <open.telemetry.api.version>1.23.0</open.telemetry.api.version>  -->
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.5</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <java.version>21</java.version>
         <!-- <vaadin.version>24.5.0.beta2</vaadin.version> -->
-        <vaadin.version>24.9.5</vaadin.version>
+        <vaadin.version>25.0.2</vaadin.version>
         <!-- How to figure this out? Go to https://github.com/vaadin/observability-kit -> Tag -> find the version that matches the vaadin-obskit jar you downloaded -> check the pom.xml property for "opentelemetry.javaagent.version" -->
         <!--<open.telemetry.annotation.version>1.23.0</open.telemetry.annotation.version>
         <open.telemetry.api.version>1.23.0</open.telemetry.api.version>  -->
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version>
+        <version>4.0.2</version>
     </parent>
 
     <repositories>

--- a/src/main/java/com/example/application/Application.java
+++ b/src/main/java/com/example/application/Application.java
@@ -3,8 +3,9 @@ package com.example.application;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
 
 /**
  * The entry point of the Spring Boot application.
@@ -14,7 +15,9 @@ import com.vaadin.flow.theme.Theme;
  *
  */
 @SpringBootApplication
-@Theme(value = "kitstest")
+@StyleSheet(Lumo.STYLESHEET)
+@StyleSheet(Lumo.UTILITY_STYLESHEET)
+@StyleSheet("themes/kitstest/styles.css")
 //@PWA(name = "KitsTest", shortName = "KitsTest", offlineResources = {})
 //@Push(transport = Transport.LONG_POLLING)
 public class Application implements AppShellConfigurator {

--- a/src/main/java/com/example/application/data/entity/SamplePerson.java
+++ b/src/main/java/com/example/application/data/entity/SamplePerson.java
@@ -1,7 +1,7 @@
 package com.example.application.data.entity;
 
 import java.time.LocalDate;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import jakarta.persistence.Entity;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/example/application/views/MainLayout.java
+++ b/src/main/java/com/example/application/views/MainLayout.java
@@ -16,13 +16,15 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.Scroller;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 
 /**
  * The main view is a top-level placeholder for other views.
  */
-public class MainLayout extends AppLayout {
+public class MainLayout extends AppLayout implements AfterNavigationObserver {
 
     private H2 viewTitle;
 
@@ -73,8 +75,7 @@ public class MainLayout extends AppLayout {
     }
 
     @Override
-    protected void afterNavigation() {
-        super.afterNavigation();
+    public void afterNavigation(AfterNavigationEvent event) {
         viewTitle.setText(getCurrentPageTitle());
     }
 

--- a/src/main/java/com/example/application/views/dashboard/DashboardView.java
+++ b/src/main/java/com/example/application/views/dashboard/DashboardView.java
@@ -4,12 +4,12 @@ package com.example.application.views.dashboard;
 import com.example.application.views.MainLayout;
 import com.example.application.views.dashboard.ServiceHealth.Status;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.board.Board;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Main;
 import com.vaadin.flow.component.html.Span;
@@ -32,12 +32,23 @@ public class DashboardView extends Main {
     public DashboardView() {
         addClassName("dashboard-view");
 
-        Board board = new Board();
-        board.addRow(createHighlight("Current users", "745", 33.7), createHighlight("View events", "54.6k", -112.45),
-                createHighlight("Conversion rate", "18%", 3.9), createHighlight("Custom metric", "-123.45", 0.0));
-        board.addRow(createViewEvents());
-        board.addRow(createServiceHealth(), createResponseTimes());
-        add(board);
+        // Row 1: Highlight cards
+        Div highlightsRow = new Div(
+                createHighlight("Current users", "745", 33.7),
+                createHighlight("View events", "54.6k", -112.45),
+                createHighlight("Conversion rate", "18%", 3.9),
+                createHighlight("Custom metric", "-123.45", 0.0));
+        highlightsRow.addClassName("dashboard-row");
+
+        // Row 2: View events chart
+        Div chartRow = new Div(createViewEvents());
+        chartRow.addClassName("dashboard-row");
+
+        // Row 3: Service health + Response times
+        Div bottomRow = new Div(createServiceHealth(), createResponseTimes());
+        bottomRow.addClassName("dashboard-row");
+
+        add(highlightsRow, chartRow, bottomRow);
     }
 
     private Component createHighlight(String title, String value, Double percentage) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,11 @@
 server.port=${PORT:8080}
 
 logging.level.org.atmosphere = warn
-spring.mustache.check-template-location = false
-
 # Launch the default browser when starting the application in development mode
 vaadin.launch-browser=false
 # To improve the performance during development.
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters
-vaadin.whitelisted-packages = com.vaadin,org.vaadin,dev.hilla,com.example.application
+vaadin.allowed-packages = com.vaadin,org.vaadin,dev.hilla,com.example.application
 spring.jpa.defer-datasource-initialization = true
 
 vaadin.frontend.hotdeploy=false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "jsx": "react-jsx",
     "inlineSources": true,
     "module": "esNext",
-    "target": "es2022",
+    "target": "es2023",
     "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Upgrade from Vaadin 24.9.5 + Spring Boot 3.5.7 to **Vaadin 25.1.1 + Spring Boot 4.0.5** (Java 21).

### What changed

| File | Change |
|------|--------|
| `pom.xml` | Vaadin 24.9.5 → 25.1.1, Spring Boot 3.5.7 → 4.0.5 |
| `Application.java` | `@Theme("kitstest")` → `@StyleSheet(Lumo.STYLESHEET)` + `@StyleSheet(Lumo.UTILITY_STYLESHEET)` + `@StyleSheet("themes/kitstest/styles.css")` |
| `DashboardView.java` | Replaced removed `Board` component with `Div` + CSS flex layout |
| `dashboard-view.css` | Updated selectors from `vaadin-board-row` to `.dashboard-row` |
| `MainLayout.java` | Implemented `AfterNavigationObserver` (protected `afterNavigation()` removed from `AppLayout` in V25) |
| `SamplePerson.java` | `javax.annotation.Nonnull` → `jakarta.annotation.Nonnull` (Jakarta EE 11) |
| `application.properties` | `vaadin.whitelisted-packages` → `vaadin.allowed-packages`, removed unused `spring.mustache.check-template-location` |
| `theme.json` | Removed `lumoImports` (silently ignored in V25) |
| `CLAUDE.md`, `README.md` | Updated version references |

### Why these changes were needed

- **`@Theme` → `@StyleSheet`**: `@Theme` still works but is deprecated. `lumoImports` in `theme.json` is silently ignored in V25, so Lumo utility CSS must be loaded explicitly via `@StyleSheet(Lumo.UTILITY_STYLESHEET)` or all flex/grid/spacing layouts break.
- **`Board` removed**: The Board component was removed in Vaadin 25. Replaced with standard `Div` elements using CSS flex layout to preserve the same visual appearance.
- **`afterNavigation()` removed**: `AppLayout` no longer exposes a protected `afterNavigation()` method. The `AfterNavigationObserver` interface is the V25 replacement.
- **`javax` → `jakarta`**: Spring Boot 4 is fully Jakarta EE 11; `javax.annotation` is no longer on the classpath.

### Verification

All 6 views verified visually identical to pre-migration state via Playwright screenshots. Functional testing confirmed: Hello World greeting, Master-Detail grid selection + form population, navigation between all views.

## Test plan

- [ ] CI build passes
- [ ] Integration tests pass (Playwright + Grafana)
- [ ] All views render correctly and match pre-migration look
- [ ] Form interactions work (Hello World, Master-Detail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)